### PR TITLE
config items separator is underscore

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -2,27 +2,27 @@
 # See LICENSE file for licensing details.
 
 options:
-  metric-count:
+  metric_count:
     type: int
     description: Number of metrics to serve.
     default: 500
-  label-count:
+  label_count:
     type: int
     description: Number of labels per-metric.
     default: 10
-  series-count:
+  series_count:
     type: int
     description: Number of series per-metric.
     default: 10
-  metricname-length:
+  metricname_length:
     type: int
     description: Modify length of metric names.
     default: 5
-  labelname-length:
+  labelname_length:
     type: int
     description: Modify length of label names.
     default: 5
-  value-interval:
+  value_interval:
     type: int
     description: Change series values every {interval} seconds.
     default: 30

--- a/src/charm.py
+++ b/src/charm.py
@@ -127,12 +127,12 @@ class AvalancheCharm(CharmBase):
         def _command():
             return (
                 f"/bin/avalanche "
-                f"--metric-count={self.config['metric-count']} "
-                f"--label-count={self.config['label-count']} "
-                f"--series-count={self.config['series-count']} "
-                f"--metricname-length={self.config['metricname-length']} "
-                f"--labelname-length={self.config['labelname-length']} "
-                f"--value-interval={self.config['value-interval']} "
+                f"--metric-count={self.config['metric_count']} "
+                f"--label-count={self.config['label_count']} "
+                f"--series-count={self.config['series_count']} "
+                f"--metricname-length={self.config['metricname_length']} "
+                f"--labelname-length={self.config['labelname_length']} "
+                f"--value-interval={self.config['value_interval']} "
                 f"--port={self.port}"
             )
 


### PR DESCRIPTION
Have all config options lowercase alphanumeric with underscore as delimiter