### PR TITLE
add series and metric intervals

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -26,6 +26,21 @@ options:
     type: int
     description: Change series values every {interval} seconds.
     default: 30
+  series_interval:
+    type: int
+    description: >
+      Change series_id label values every {interval} seconds.
+      Avalanche's CLI default value is 60, but this is too low and quickly overloads the scraper.
+      Using 3600000 (10k hours ~ 1 year) in lieu of "inf" (never refresh).
+    default: 36000000
+  metric_interval:
+    type: int
+    description: >
+      Change __name__ label values every {interval} seconds.
+      Avalanche's CLI default value is 120, but this is too low and quickly overloads the scraper.
+      Using 3600000 (10k hours ~ 1 year) in lieu of "inf" (never refresh).
+    default: 36000000
+    
 
 
 #  --const-label=CONST-LABEL ...  Constant label to add to every metric. Format
@@ -33,10 +48,6 @@ options:
 #                                 multiple times.
 
 
-#  --series-interval=60           Change series_id label values every {interval}
-#                                 seconds.
-#  --metric-interval=120          Change __name__ label values every {interval}
-#                                 seconds.
 #  --port=9001                    Port to serve at
 #  --remote-url=REMOTE-URL        URL to send samples via remote_write API.
 #  --remote-pprof-urls=REMOTE-PPROF-URLS ...

--- a/src/charm.py
+++ b/src/charm.py
@@ -133,6 +133,8 @@ class AvalancheCharm(CharmBase):
                 f"--metricname-length={self.config['metricname_length']} "
                 f"--labelname-length={self.config['labelname_length']} "
                 f"--value-interval={self.config['value_interval']} "
+                f"--series-interval={self.config['series_interval']} "
+                f"--metric-interval={self.config['metric_interval']} "
                 f"--port={self.port}"
             )
 


### PR DESCRIPTION
This PR adds two useful config options:
- series_interval
- metric_interval

Hopefully soon these args could be set to "inf" (never refresh):
https://github.com/prometheus-community/avalanche/pull/28